### PR TITLE
Add link to GitHub on a Hex summary page

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,8 @@ defmodule Exml.Mixfile do
   defp package do
     [
       files: ["lib", "priv", "mix.exs", "README*"],
-      maintainers: ["expelledboy"]
+      maintainers: ["expelledboy"],
+      links: %{"GitHub" => "https://github.com/expelledboy/exml"},
     ]
   end
 end


### PR DESCRIPTION
Hi!

This provides a link on a Hex page for this project, making easy to discover this GitHub repository.
